### PR TITLE
v2.0.1 Tools Release

### DIFF
--- a/tools/arribada_tools/__init__.py
+++ b/tools/arribada_tools/__init__.py
@@ -4,4 +4,4 @@ from .gps_config import *
 from .backend import *
 from .log import *
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'

--- a/tools/arribada_tools/ble.py
+++ b/tools/arribada_tools/ble.py
@@ -105,9 +105,14 @@ class BluetoothTracker():
         return self._buffer.read(self._buffer.occupancy())
 
     def readFull(self, length, timeout=0):
-        # Read up until length has been reached
-        while self._buffer.occupancy() < length:
+        # Read up until length has been reached or we timeout
+        current_occupancy = self._buffer.occupancy()
+        while current_occupancy < length:
             self._periph.waitForNotifications(timeout)
+            if current_occupancy == self._buffer.occupancy():
+                logger.error("Receive timed out")
+                break
+            current_occupancy = self._buffer.occupancy()
         return self._buffer.read(length)
 
     def cleanup(self):

--- a/tools/arribada_tools/config.py
+++ b/tools/arribada_tools/config.py
@@ -806,9 +806,9 @@ class ConfigItem_BLE_DeviceAddress(ConfigItem):
     def unpack(self, data):
         ConfigItem.unpack(self, data)
         device_id = binascii.hexlify(self.deviceAddress[::-1])
-        new_id = b''
+        new_id = ""
         for i in range(len(device_id)):
-            new_id = new_id + device_id[i]
+            new_id = new_id + chr(device_id[i]).upper()
             if i & 1 and i != (len(device_id)-1):
                 new_id = new_id + ':'
         self.deviceAddress = new_id
@@ -1364,9 +1364,9 @@ class ConfigItem_IOT_Satellite_Artic(ConfigItem):
         ConfigItem.unpack(self, data)
 
         device_id = binascii.hexlify(self.deviceAddress[::-1])
-        new_id = b''
+        new_id = ""
         for i in range(len(device_id)):
-            new_id = new_id + device_id[i]
+            new_id = new_id + chr(device_id[i]).upper()
             if i & 1 and i != (len(device_id)-1):
                 new_id = new_id + ':'
         self.deviceAddress = new_id
@@ -1379,13 +1379,13 @@ class ConfigItem_IOT_Satellite_Artic(ConfigItem):
         while i < len(bulletin_raw):
             (sat_code, timestamp, f1, f2, f3, f4, f5, f6) = struct.unpack_from(fmt, bulletin_raw, i)
             i = i + struct.calcsize(fmt)
-            if sat_code[0] != '\x00':
-                bulletin.append({'satelliteCode':sat_code,
+            if sat_code[0] != 0:
+                bulletin.append({'satelliteCode':sat_code.decode('ascii'),
                                  'secondsSinceEpoch':timestamp,
                                  'params': [f1,f2,f3,f4,f5,f6]})
             else:
                 break
-
+        
         self.bulletin = bulletin
 
 

--- a/tools/tests/ble_auto
+++ b/tools/tests/ble_auto
@@ -129,7 +129,7 @@ class Device(object):
         self._log_download_success = args.log_skip_download
         self._log_erase_flag = args.log_erase
         self._log_create_flag = args.log_create
-        self._get_status_flag = True
+        self._get_status_flag = False
         self._config_flag = config_data
         self._fw_main_flag = fw_main_data
         self._fw_ble_flag = fw_ble_data


### PR DESCRIPTION
1. Fixes parsing of Artic configuration with `tracker_config --read_config` introduced when porting to Python3
2. Fixes parsing of BLE address with `tracker_config --read_config` introduced when porting to Python3
3. Fixes certain BLE reads hanging indefinitely instead of timing out
4. Fixes `tracker_config --read_log` failing over BLE