### PR TITLE
v10.0rc1 Firmware Release

### DIFF
--- a/firmware/v4/devices/gps/M8N/M8N.c
+++ b/firmware/v4/devices/gps/M8N/M8N.c
@@ -429,7 +429,10 @@ static void syshal_gps_process_nav_pvt_priv(const UBX_Packet_t * packet)
     event.pvt.hAcc = packet->UBX_NAV_PVT.hAcc;
     event.pvt.vAcc = packet->UBX_NAV_PVT.vAcc;
 
-    event.pvt.date_time_valid = packet->UBX_NAV_PVT.valid & (UBX_NAV_PVT_VALID_FLAGS_DATE | UBX_NAV_PVT_VALID_FLAGS_TIME);
+    if ((packet->UBX_NAV_PVT.valid & UBX_NAV_PVT_VALID_FLAGS_DATE) && (packet->UBX_NAV_PVT.valid & UBX_NAV_PVT_VALID_FLAGS_TIME))
+        event.pvt.date_time_valid = true;
+    else
+        event.pvt.date_time_valid = false;
 
     if (event.pvt.date_time_valid)
     {

--- a/firmware/v4/ports/nrf52840/CMakeLists.txt
+++ b/firmware/v4/ports/nrf52840/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 project(Horizon
-    VERSION 10.0.2.0
+    VERSION 10.0.2.1
     LANGUAGES C ASM
 )
 


### PR DESCRIPTION
1. Fix a saltwater switch hysteresis period of less than 3 seconds causing constant surfaced/submerged event logging
2. Fix possibility for an invalid GPS time to be interpreted as valid